### PR TITLE
Incorrect cache key in ConnectionServiceRepository

### DIFF
--- a/src/com/android/server/telecom/ConnectionServiceRepository.java
+++ b/src/com/android/server/telecom/ConnectionServiceRepository.java
@@ -41,7 +41,9 @@ final class ConnectionServiceRepository {
                 @Override
                 public void onUnbind(ConnectionServiceWrapper service) {
                     synchronized (mLock) {
-                        mServiceCache.remove(service.getComponentName());
+                        Pair<ComponentName, UserHandle> cacheKey = Pair.create(
+                                service.getComponentName(), service.getUserHandle());
+                        mServiceCache.remove(cacheKey);
                     }
                 }
             };

--- a/src/com/android/server/telecom/ServiceBinder.java
+++ b/src/com/android/server/telecom/ServiceBinder.java
@@ -167,7 +167,7 @@ abstract class ServiceBinder {
     private ServiceConnection mServiceConnection;
 
     /** {@link UserHandle} to use for binding, to support work profiles and multi-user. */
-    private UserHandle mUserHandle;
+    private final UserHandle mUserHandle;
 
     /** The binder provided by {@link ServiceConnection#onServiceConnected} */
     private IBinder mBinder;
@@ -251,6 +251,10 @@ abstract class ServiceBinder {
 
     final ComponentName getComponentName() {
         return mComponentName;
+    }
+
+    final UserHandle getUserHandle() {
+        return mUserHandle;
     }
 
     final boolean isServiceValid(String actionName) {


### PR DESCRIPTION
Pair of commponentName and userHandle is correct cache key.
ConnectionService can be leaked after unbind.

Change-Id: Ib2896917fd28ba45c5371aa7c6b2eb3a0c867eb8