### PR TITLE
CallsManager: Fix racey disconnect-on-waiting

### DIFF
--- a/src/com/android/server/telecom/CallsManager.java
+++ b/src/com/android/server/telecom/CallsManager.java
@@ -2514,25 +2514,25 @@ public class CallsManager extends Call.ListenerBase implements VideoProviderProx
             // on-hold before answering the new call.
             // TODO: Import logic from
             // CallManager.acceptCall()
-            updateListeners();
+            updateListeners(false);
         }
 
         private void handleEndCallAndAnswer() {
             // We don't want to hold, just disconnect
 
-            Log.v(this, "Disconnecting active/dialing call %s before answering incoming call %s.",
+            Log.v(this, "Holding active/dialing call %s for termination before answering incoming call %s.",
                     mLocalCallsManager.mForegroundCall, mNewCall);
 
-            mActiveCall.disconnect();
+            mActiveCall.hold();
             // TODO: Wait until we get confirmation of
             // the active call being
             // on-hold before answering the new call.
             // TODO: Import logic from
             // CallManager.acceptCall()
-            updateListeners();
+            updateListeners(true);
         }
 
-        private void updateListeners() {
+        private void updateListeners(boolean terminateActive) {
             for (CallsManagerListener listener : mLocalCallsManager.mListeners) {
                 listener.onIncomingCallAnswered(mNewCall);
             }
@@ -2542,6 +2542,12 @@ public class CallsManager extends Call.ListenerBase implements VideoProviderProx
             // the answer() through
             // {@link #markCallAsActive}.
             mNewCall.answer(mVideoState);
+            if (terminateActive && mActiveCall != null) {
+                Log.v(this, "Terminating active call %s after answering incoming call %s.",
+                    mActiveCall, mNewCall);
+                mActiveCall.disconnect();
+            }
+
             if (mLocalCallsManager.isSpeakerphoneAutoEnabled(mVideoState)) {
                 mNewCall.setStartWithSpeakerphoneOn(true);
             }


### PR DESCRIPTION
Disconnecting the active call and then immediately answering the
background was timing dependent. If the disconnection was ongoing
at the time of answering the other call, the switch request caused
by the answer could trample the call IDs or the internal state
machine of the radio.

As a not-so-pretty fix, move the call to background before
disconnecting it so that the switch happens first.

Change-Id: I1b4c251a9419991fe96ee0951e4a14a6f25ccc8d
Still: CYNGNOS-1593